### PR TITLE
feat(docs): add another bad example to spacing

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -105,6 +105,8 @@ Bad:
 
 > 剛剛買了一部 iPhone ，好開心！
 
+> 剛剛買了一部 iPhone， 好開心！
+
 ### `-ms-text-autospace` to the rescue?
 
 Microsoft provides a CSS property [`-ms-text-autospace`](http://msdn.microsoft.com/en-us/library/ie/ms531164(v=vs.85).aspx) that can specify the autospacing and narrow space width adjustment of text. However it's not popular, and on other platforms such as OS X and iOS we can not use this feature. So it's better for you to keep up the habit.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Other languages:
 
 > 剛剛買了一部 iPhone ，好開心！
 
+> 剛剛買了一部 iPhone， 好開心！
+
 ### `-ms-text-autospace` to the rescue?
 
 Microsoft 有個 [`-ms-text-autospace`](http://msdn.microsoft.com/en-us/library/ie/ms531164(v=vs.85).aspx) 的 CSS 屬性可以實現自動為中英文之間增加空白。不過目前並未普及，另外在其他應用場景，例如 OS X、iOS 的用戶介面目前并不存在這個特性，所以請繼續保持隨手加空格的習慣。


### PR DESCRIPTION
Sometimes, additional spaces are added before/after punctuation in fullwidth,
especially in copying Chinese translation in Google Translate. It's better to
avoid spacing in this situation, or it looks wider than normal.