### PR TITLE
docs(README): remove zh-CN wrong space

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -34,12 +34,12 @@
 错误：
 
 > 在LeanCloud上，数据存储是围绕`AVObject`进行的。
-> 
+>
 > 在 LeanCloud上，数据存储是围绕`AVObject` 进行的。
 
 完整的正确用法：
 
-> 在 LeanCloud 上，数据存储是围绕 `AVObject` 进行的。 每个 `AVObject` 都包含了与 JSON 兼容的 key-value 对应的数据。 数据是 schema-free 的，你不需要在每个 `AVObject` 上提前指定存在哪些键，只要直接设定对应的 key-value 即可。
+> 在 LeanCloud 上，数据存储是围绕 `AVObject` 进行的。每个 `AVObject` 都包含了与 JSON 兼容的 key-value 对应的数据。数据是 schema-free 的，你不需要在每个 `AVObject` 上提前指定存在哪些键，只要直接设定对应的 key-value 即可。
 
 例外：「豆瓣FM」等产品名词，按照官方所定义的格式书写。
 
@@ -52,7 +52,7 @@
 错误：
 
 > 今天出去买菜花了 5000元。
-> 
+>
 > 今天出去买菜花了5000元。
 
 ### 数字与单位之间需要增加空格
@@ -70,13 +70,13 @@
 正确：
 
 > 今天是 233° 的高温。
-> 
+>
 > 新 MacBook Pro 有 15% 的 CPU 性能提升。
 
 错误：
 
 > 今天是 233 ° 的高温。
-> 
+>
 > 新 MacBook Pro 有 15 % 的 CPU 性能提升。
 
 ### 全角标点与其他字符之间不加空格
@@ -88,7 +88,7 @@
 错误：
 
 > 刚刚买了一部 iPhone ，好开心！
-> 
+>
 > 刚刚买了一部 iPhone， 好开心！
 
 ### 用 `text-spacing` 来挽救？
@@ -102,17 +102,17 @@ CSS Text Module Level 4 的 [`text-spacing`](https://www.w3.org/TR/css-text-4/#t
 正确：
 
 > 德国队竟然战胜了巴西队！
-> 
+>
 > 她竟然对你说「喵」？！
 
 错误：
 
 > 德国队竟然战胜了巴西队！！
-> 
+>
 > 德国队竟然战胜了巴西队！！！！！！！！
-> 
+>
 > 她竟然对你说「喵」？？！！
-> 
+>
 > 她竟然对你说「喵」？！？！？？！！
 
 ## 全角和半角
@@ -124,17 +124,17 @@ CSS Text Module Level 4 的 [`text-spacing`](https://www.w3.org/TR/css-text-4/#t
 正确：
 
 > 嗨！你知道嘛？今天前台的小妹跟我说「喵」了哎！
-> 
+>
 > 核磁共振成像（NMRI）是什么原理都不知道？JFGI！
 
 错误：
 
 > 嗨! 你知道嘛? 今天前台的小妹跟我说 "喵" 了哎！
-> 
+>
 > 嗨!你知道嘛?今天前台的小妹跟我说"喵"了哎！
-> 
+>
 > 核磁共振成像 (NMRI) 是什么原理都不知道? JFGI!
-> 
+>
 > 核磁共振成像(NMRI)是什么原理都不知道?JFGI!
 
 ### 数字使用半角字符
@@ -154,13 +154,13 @@ CSS Text Module Level 4 的 [`text-spacing`](https://www.w3.org/TR/css-text-4/#t
 正确：
 
 > 贾伯斯那句话是怎么说的？「Stay hungry, stay foolish.」
-> 
+>
 > 推荐你阅读《Hackers & Painters: Big Ideas from the Computer Age》，非常的有趣。
 
 错误：
 
 > 贾伯斯那句话是怎么说的？「Stay hungry，stay foolish。」
-> 
+>
 > 推荐你阅读《Hackers＆Painters：Big Ideas from the Computer Age》，非常的有趣。
 
 ## 名词
@@ -172,29 +172,29 @@ CSS Text Module Level 4 的 [`text-spacing`](https://www.w3.org/TR/css-text-4/#t
 正确：
 
 > 使用 GitHub 登录
-> 
+>
 > 我们的客户有 GitHub、Foursquare、Microsoft Corporation、Google、Facebook, Inc.。
 
 错误：
 
 > 使用 github 登录
-> 
+>
 > 使用 GITHUB 登录
-> 
+>
 > 使用 Github 登录
-> 
+>
 > 使用 gitHub 登录
-> 
+>
 > 使用 gｲんĤЦ8 登录
-> 
+>
 > 我们的客户有 github、foursquare、microsoft corporation、google、facebook, inc.。
-> 
+>
 > 我们的客户有 GITHUB、FOURSQUARE、MICROSOFT CORPORATION、GOOGLE、FACEBOOK, INC.。
-> 
+>
 > 我们的客户有 Github、FourSquare、MicroSoft Corporation、Google、FaceBook, Inc.。
-> 
+>
 > 我们的客户有 gitHub、fourSquare、microSoft Corporation、google、faceBook, Inc.。
-> 
+>
 > 我们的客户有 gｲんĤЦ8、ｷouЯƧquﾑгє、๓เςг๏ร๏Ŧt ς๏гק๏гคtเ๏ภn、900913、ƒ4ᄃëв๏๏к, IПᄃ.。
 
 注意：当网页中需要配合整体视觉风格而出现全部大写／小写的情形，HTML 中请使用标淮的大小写规范进行书写；并通过 `text-transform: uppercase;`／`text-transform: lowercase;` 对表现形式进行定义。
@@ -218,13 +218,13 @@ CSS Text Module Level 4 的 [`text-spacing`](https://www.w3.org/TR/css-text-4/#t
 用法：
 
 > 请 [提交一个 issue](#) 并分配给相关同事。
-> 
+>
 > 访问我们网站的最新动态，请 [点击这里](#) 进行订阅！
 
 对比用法：
 
 > 请[提交一个 issue](#)并分配给相关同事。
-> 
+>
 > 访问我们网站的最新动态，请[点击这里](#)进行订阅！
 
 ### 简体中文使用直角引号


### PR DESCRIPTION
移除了简体中文文档示例中，全角标点与中文字符间错误出现的空格。

ref #91